### PR TITLE
Fix text mojibake when push sd tickets to hiveminder

### DIFF
--- a/lib/Net/Jifty.pm
+++ b/lib/Net/Jifty.pm
@@ -458,7 +458,7 @@ sub escape {
     my $self = shift;
 
     return map { s/([^a-zA-Z0-9_.!~*'()-])/uc sprintf("%%%02X", ord $1)/eg; $_ }
-           map { Encode::encode_utf8($_) }
+           map { Encode::is_utf8($_) ? Encode::encode_utf8($_) : $_ }
            @_
 }
 


### PR DESCRIPTION
Hi bestpractical,

I was having text mojibake when I push my sd tickets with chinese summary to hiveminder. To reproduce, do the following (assuming using utf8 terminal / editor / etc):

```
0. init a new sd repo
1. sd ticket create; # put chinese characters in there, e.g., 中文
2. sd push --to hm:http://hiveminder.com
3. open http://hiveminder.com with browser and see a messy summary line
```

sd is, of course, the latest version, the test is done with perl 5.14.1. Notice in local, `sd ticket list` still display it correctly. It only messed up on hiveminder side.

Traced down to `Net::Jifty` and figured all args passed to `act` or `post` etc need to be in wide characters in order to avoid the bug. The cause of mojibake is the call to `Encode::encode_utf8` on `$_` that does not contain wide characters, i.e., `Encode::is_utf8($_)` is false. The fix is rather simple to understand.

A simple hiveminder client is written to help me reproducing the bug: https://gist.github.com/1221882

In that code, `Encode::is_utf8($summary)`  is false because `@ARGV` are not wide characters even if Chinese characters are in there. If `$summary = Encode::decode_utf8($summary)` is called right before the statement of `create(....)`, then the task is created correctly with `Net::Jifty 0.14`.

 I know that this can probably be fixed in sd instead. However, by fixing it in `Net::Jifty` it makes the usage easier (no need to ensure the utf8-ness of strings) and benefit sub-classes and users.
